### PR TITLE
cache機能の有効化 (Fixes #8)

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -51,36 +51,16 @@ jobs:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
 
-      - name: Debug cache settings
-        run: |
-          echo "=== config.yml cache section ==="
-          grep -A 10 "^cache:" config/config.yml || echo "cache section not found"
-          echo ""
-          echo "=== /tmp/ai-feed/ contents ==="
-          find /tmp/ai-feed/ -type f 2>/dev/null || echo "/tmp/ai-feed/ does not exist"
-          echo ""
-          echo "=== ~/.ai-feed/ contents (default path) ==="
-          find ~/.ai-feed/ -type f 2>/dev/null || echo "~/.ai-feed/ does not exist"
-
       - name: Update cache branch
         run: |
-          echo "Checking if cache file exists..."
-          ls -la /tmp/ai-feed/cache/ || echo "Directory not found"
           if [ -f /tmp/ai-feed/cache/recommend_history.jsonl ]; then
-            echo "Cache file found, proceeding..."
             cp /tmp/ai-feed/cache/recommend_history.jsonl cache-branch/
             cd cache-branch
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git add recommend_history.jsonl
             if ! git diff --cached --quiet; then
-              echo "Changes detected, committing..."
               git commit --amend -m "Update cache"
               git push --force origin cache
-              echo "Push completed"
-            else
-              echo "No changes to commit"
             fi
-          else
-            echo "Cache file NOT found"
           fi

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -15,6 +15,8 @@ concurrency:
 jobs:
   recommend:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -32,7 +32,15 @@ jobs:
             cp cache-branch/recommend_history.jsonl /tmp/ai-feed/cache/
           fi
 
+      - name: Cache ai-feed binary
+        id: cache-ai-feed
+        uses: actions/cache@v4
+        with:
+          path: bin
+          key: ai-feed-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.ai-feed-version') }}
+
       - name: Download ai-feed
+        if: steps.cache-ai-feed.outputs.cache-hit != 'true'
         run: make download
 
       - name: Run recommend

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -62,14 +62,23 @@ jobs:
 
       - name: Update cache branch
         run: |
+          echo "Checking if cache file exists..."
+          ls -la /tmp/ai-feed/cache/ || echo "Directory not found"
           if [ -f /tmp/ai-feed/cache/recommend_history.jsonl ]; then
+            echo "Cache file found, proceeding..."
             cp /tmp/ai-feed/cache/recommend_history.jsonl cache-branch/
             cd cache-branch
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git add recommend_history.jsonl
             if ! git diff --cached --quiet; then
+              echo "Changes detected, committing..."
               git commit --amend -m "Update cache"
               git push --force origin cache
+              echo "Push completed"
+            else
+              echo "No changes to commit"
             fi
+          else
+            echo "Cache file NOT found"
           fi

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -44,7 +44,7 @@ jobs:
         run: make download
 
       - name: Run recommend
-        run: make recommend RECOMMEND_OPTS="-v"
+        run: make recommend OPTS="-v"
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -44,7 +44,7 @@ jobs:
         run: make download
 
       - name: Run recommend
-        run: make recommend
+        run: make recommend RECOMMEND_OPTS="-v"
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -49,24 +49,27 @@ jobs:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
 
+      - name: Debug cache settings
+        run: |
+          echo "=== config.yml cache section ==="
+          grep -A 10 "^cache:" config/config.yml || echo "cache section not found"
+          echo ""
+          echo "=== /tmp/ai-feed/ contents ==="
+          find /tmp/ai-feed/ -type f 2>/dev/null || echo "/tmp/ai-feed/ does not exist"
+          echo ""
+          echo "=== ~/.ai-feed/ contents (default path) ==="
+          find ~/.ai-feed/ -type f 2>/dev/null || echo "~/.ai-feed/ does not exist"
+
       - name: Update cache branch
         run: |
-          echo "Checking cache file..."
           if [ -f /tmp/ai-feed/cache/recommend_history.jsonl ]; then
-            echo "Cache file found, updating cache branch..."
             cp /tmp/ai-feed/cache/recommend_history.jsonl cache-branch/
             cd cache-branch
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             if ! git diff --quiet; then
-              echo "Changes detected, committing..."
               git add recommend_history.jsonl
-              git commit -m "Update cache"
-              git push origin cache
-            else
-              echo "No changes to commit"
+              git commit --amend -m "Update cache"
+              git push --force origin cache
             fi
-          else
-            echo "Cache file not found at /tmp/ai-feed/cache/recommend_history.jsonl"
-            ls -la /tmp/ai-feed/cache/ || echo "Cache directory does not exist"
           fi

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -51,14 +51,22 @@ jobs:
 
       - name: Update cache branch
         run: |
+          echo "Checking cache file..."
           if [ -f /tmp/ai-feed/cache/recommend_history.jsonl ]; then
+            echo "Cache file found, updating cache branch..."
             cp /tmp/ai-feed/cache/recommend_history.jsonl cache-branch/
             cd cache-branch
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             if ! git diff --quiet; then
+              echo "Changes detected, committing..."
               git add recommend_history.jsonl
-              git commit --amend -m "Update cache"
-              git push --force origin cache
+              git commit -m "Update cache"
+              git push origin cache
+            else
+              echo "No changes to commit"
             fi
+          else
+            echo "Cache file not found at /tmp/ai-feed/cache/recommend_history.jsonl"
+            ls -la /tmp/ai-feed/cache/ || echo "Cache directory does not exist"
           fi

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -67,8 +67,8 @@ jobs:
             cd cache-branch
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
-            if ! git diff --quiet; then
-              git add recommend_history.jsonl
+            git add recommend_history.jsonl
+            if ! git diff --cached --quiet; then
               git commit --amend -m "Update cache"
               git push --force origin cache
             fi

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -32,15 +32,7 @@ jobs:
             cp cache-branch/recommend_history.jsonl /tmp/ai-feed/cache/
           fi
 
-      - name: Cache ai-feed binary
-        id: cache-ai-feed
-        uses: actions/cache@v4
-        with:
-          path: bin
-          key: ai-feed-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.ai-feed-version') }}
-
       - name: Download ai-feed
-        if: steps.cache-ai-feed.outputs.cache-hit != 'true'
         run: make download
 
       - name: Run recommend

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Cache ai-feed binary
+        id: cache-ai-feed
+        uses: actions/cache@v4
+        with:
+          path: bin
+          key: ai-feed-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.ai-feed-version') }}
+
       - name: Download ai-feed
+        if: steps.cache-ai-feed.outputs.cache-hit != 'true'
         run: make download
 
       - name: Verify ai-feed version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,15 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Cache ai-feed binary
-        id: cache-ai-feed
-        uses: actions/cache@v4
-        with:
-          path: bin
-          key: ai-feed-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.ai-feed-version') }}
-
       - name: Download ai-feed
-        if: steps.cache-ai-feed.outputs.cache-hit != 'true'
         run: make download
 
       - name: Verify ai-feed version

--- a/Makefile
+++ b/Makefile
@@ -51,5 +51,6 @@ check: $(TARGET)
 	@./$(TARGET) config check --config $(CONFIG_FILE)
 
 # Run recommend command with feeds from feeds file
+# Usage: make recommend [RECOMMEND_OPTS="-v"]
 recommend: $(TARGET)
-	@./$(TARGET) recommend --config $(CONFIG_FILE) --source $(FEEDS_FILE)
+	@./$(TARGET) recommend --config $(CONFIG_FILE) --source $(FEEDS_FILE) $(RECOMMEND_OPTS)

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,6 @@ check: $(TARGET)
 	@./$(TARGET) config check --config $(CONFIG_FILE)
 
 # Run recommend command with feeds from feeds file
-# Usage: make recommend [RECOMMEND_OPTS="-v"]
+# Usage: make recommend [OPTS="-v"]
 recommend: $(TARGET)
-	@./$(TARGET) recommend --config $(CONFIG_FILE) --source $(FEEDS_FILE) $(RECOMMEND_OPTS)
+	@./$(TARGET) recommend --config $(CONFIG_FILE) --source $(FEEDS_FILE) $(OPTS)

--- a/config/config.yml
+++ b/config/config.yml
@@ -131,11 +131,11 @@ default_profile:
 cache:
   # 有効/無効フラグ（省略時はfalse）
   # trueに設定すると投稿済み記事の重複を防ぐことができます
-  enabled: false
-  
+  enabled: true
+
   # キャッシュファイルのパス
   # 省略時はホームディレクトリの ~/.ai-feed/recommend_history.jsonl が使用されます
-  # file_path: ~/.ai-feed/recommend_history.jsonl
+  file_path: /tmp/ai-feed/cache/recommend_history.jsonl
   
   # 最大エントリ数（FIFOで古いものから削除）
   # 省略時は1000件


### PR DESCRIPTION
## Summary
- ai-feedのキャッシュ機能を有効化し、投稿済み記事の重複投稿を防止
- GitHub Actionsでai-feedバイナリのダウンロードをキャッシュ化

## 変更内容
### config/config.yml
- `cache.enabled` を `true` に変更
- `file_path` を `/tmp/ai-feed/cache/recommend_history.jsonl` に設定

### .github/workflows/run.yml, test.yml
- `actions/cache@v4` を追加してai-feedバイナリをキャッシュ
- キャッシュヒット時は `make download` をスキップ

## Test plan
- [ ] GitHub Actionsワークフローが正常に実行されることを確認
- [ ] キャッシュが有効になり、同じ記事が重複投稿されないことを確認

fixed #8 