### PR TITLE
定期実行のscheduleトリガーを削除しSlack投稿を停止

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -1,11 +1,6 @@
 name: Run AI Feed
 
 on:
-  schedule:
-    # Run at 8:00, 12:00, and 16:00 JST (23:00, 03:00, 07:00 UTC)
-    - cron: '0 23 * * *'
-    - cron: '0 3 * * *'
-    - cron: '0 7 * * *'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary
- 別の情報取得方法に切り替えたため、GitHub Actionsの定期実行（Slack投稿含む）を停止する
- `.github/workflows/run.yml` の `schedule` トリガー（JST 8:00/12:00/16:00）を削除
- `workflow_dispatch`（手動実行）は引き続き利用可能

## Test plan
- [x] `run.yml` のYAML構文を確認（`schedule` セクション削除のみで他のジョブ定義に変更なし）
- [ ] マージ後、Actionsタブでscheduleが表示されなくなっていることを確認

---
_Generated by [Claude Code](https://claude.ai/code/session_01GQBcAiTbV7528nJ58NVzR2)_